### PR TITLE
fiz safari issue

### DIFF
--- a/src/gridlex.scss
+++ b/src/gridlex.scss
@@ -11,14 +11,14 @@
   flex-flow: row wrap;
   margin: 0 (-$gl-gutter/2);
 }
+.#{$gl-colName}{
+  flex: 1 1 0%;
+}
 .#{$gl-colName},
 [class*="#{$gl-colName}-"]{
   box-sizing: border-box;
   flex: 0 0 auto;
   padding: 0 ($gl-gutter/2) $gl-col-bottom;
-}
-.#{$gl-colName}{
-  flex: 1 1 0%;
 }
 .#{$gl-gridName}.#{$gl-colName},
 .#{$gl-gridName}[class*="#{$gl-colName}-"]{


### PR DESCRIPTION
I noticed that safari was ignoring the `flex: 0 0 auto;` because `flex: 1 1 0%;` came bellow. So I just moved it to above.