### PR TITLE
Added "-noWrap" helper to grid classes.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1352,7 +1352,8 @@ OR
 
   -noGutter
   -equalHeight
-  -noBottom</code></pre>
+  -noBottom
+  -noWrap</code></pre>
 
         <h2>Columns &amp; associated classes: </h2>
         <pre class="doc"><code>.col

--- a/src/gridlex.less
+++ b/src/gridlex.less
@@ -38,6 +38,11 @@
       padding: 0;
     }
   }
+  
+// No Wrapping
+  &[class*="-noWrap"]{
+    flex-wrap: nowrap;
+  }
 
 // Horizontal alignment
   &[class*="-center"]{

--- a/src/gridlex.scss
+++ b/src/gridlex.scss
@@ -39,6 +39,10 @@
     }
   }
 
+// No Wrapping
+  &[class*="-noWrap"]{
+    flex-wrap: nowrap;
+  }
 // Horizontal alignment
   &[class*="-center"]{
     justify-content: center;


### PR DESCRIPTION
In certain situations it can be very helpful to not have a grid element automatically wrap to the next line. This helper will simple set `flex-wrap` to `flex-wrap: nowrap`.