### PR TITLE
Fix typo 'gl-*-_md-0' to 'gl-*_md-0'

### DIFF
--- a/src/gridlex.less
+++ b/src/gridlex.less
@@ -187,14 +187,14 @@
 }
 @media @gl-md{
   [class*="@{gl-gridName}"] {
-    > :not([class*="_-md-0"]){
+    > :not([class*="_md-0"]){
       display: block;
     }
-    &:not([class*="_-md-0"]) {
+    &:not([class*="_md-0"]) {
       display: flex;
     }
-    >[class*="_-md-0"],
-    &[class*="-equalHeight"] > [class*="_-md-0"]{
+    >[class*="_md-0"],
+    &[class*="-equalHeight"] > [class*="_md-0"]{
       display: none;
     }
   }


### PR DESCRIPTION
`gl-*-_md-0` should be `gl-*_md-0` in the gridlex.less.
It seems fine in the SCSS version.