### PR TITLE
feature: add dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "url": "git@github.com:devlint/gridlex.git"
   },
   "license": "MIT",
-  "main": "src/gridlex.scss",
+  "main": "dist/gridlex.min.css",
   "sass": "src/gridlex.scss",
   "style": "docs/gridlex.css",
   "scripts": {
-    "sass": "node-sass src/gridlex.scss --sourceMap docs/ -o docs/ && postcss docs/gridlex.css > docs/gridlex.min.css"
+    "version": "npm run dist && git add -A .",
+    "dist": "node-sass src/gridlex.scss --sourceMap dist/ -o dist/ && postcss dist/gridlex.css > dist/gridlex.min.css",
+    "docs": "cp -R dist/ docs"
   },
   "devDependencies": {
     "cssnano": "^3.10.0",


### PR DESCRIPTION
this would fix downstream expectations to consume the library without compiling. Also having `dist` in `docs` is kinda counterintuitive.

I encountered that problem when compiling with webpack in a Vue.js project. This caused me a major headache.

I am sure you want to adapt this to your needs, but I would highly advise making a change like that to get more adoption of your great library.