### PR TITLE
Added missing !default modifier to variable $gl-colCount

### DIFF
--- a/src/gridlex-vars.scss
+++ b/src/gridlex-vars.scss
@@ -1,7 +1,7 @@
 //************************
 //    VARIABLES
 //************************
-$gl-colCount:   12;
+$gl-colCount:   12 !default;
 $gl-gridName:   grid !default;
 $gl-colName:   col !default;
 $gl-attributeName: class !default;


### PR DESCRIPTION
I forgot to add the `!default` modifier to variable `$gl-colCount` while implementing #74 